### PR TITLE
Fix (Exist): File.exists method is deprecated and no longer exist

### DIFF
--- a/lib/pdftoimage.rb
+++ b/lib/pdftoimage.rb
@@ -33,7 +33,7 @@ module PDFToImage
         #
         # @return [Array] An array of images
         def open(filename, &block)
-            if not File.exists?(filename)
+            if not File.exist?(filename)
                 raise PDFError, "File '#{filename}' not found."
             end
 

--- a/spec/pdftoimage_spec.rb
+++ b/spec/pdftoimage_spec.rb
@@ -17,7 +17,7 @@ describe PDFToImage do
     #       @pages = PDFToImage.open('spec/weird_utf8.pdf')
     #   @pages.size.should equal 1
     #   @pages[0].resize('50%').save('spec/tmp1.jpg')
-    #   File.exists?('spec/tmp1.jpg').should equal true
+    #   File.exist?('spec/tmp1.jpg').should equal true
     #   File.unlink('spec/tmp1.jpg')
     #    end
     #  end
@@ -32,7 +32,7 @@ describe PDFToImage do
             @pages = PDFToImage.open('spec/3pages.pdf')
             @pages.each do |page|
                 page.save('spec/tmp.jpg')
-                File.exists?('spec/tmp.jpg').should equal true
+                File.exist?('spec/tmp.jpg').should equal true
                 File.unlink('spec/tmp.jpg')
             end
         end
@@ -40,7 +40,7 @@ describe PDFToImage do
         it "should allow resizing and quality control" do
             @pages = PDFToImage.open('spec/3pages.pdf')
             @pages[0].resize('50%').quality('80%').save('spec/tmp2.jpg')
-            File.exists?('spec/tmp2.jpg').should equal true
+            File.exist?('spec/tmp2.jpg').should equal true
             File.unlink('spec/tmp2.jpg')
         end
 
@@ -58,7 +58,7 @@ describe PDFToImage do
             counter = 0
             PDFToImage.open('spec/10pages.pdf') do |page|
                 result = page.save("spec/10pg-#{page.page}.jpg")
-                File.exists?("spec/10pg-#{page.page}.jpg").should equal true
+                File.exist?("spec/10pg-#{page.page}.jpg").should equal true
                 File.unlink("spec/10pg-#{page.page}.jpg")
                 counter = counter + 1
             end
@@ -70,7 +70,7 @@ describe PDFToImage do
             counter = 0
             PDFToImage.open('spec/11pages.pdf') do |page|
                 result = page.save("spec/11pg-#{page.page}.jpg")
-                File.exists?("spec/11pg-#{page.page}.jpg").should equal true
+                File.exist?("spec/11pg-#{page.page}.jpg").should equal true
                 File.unlink("spec/11pg-#{page.page}.jpg")
                 counter = counter + 1
             end


### PR DESCRIPTION
Hello :) 

We currently have an issue with upgrading our Monolith to Ruby 3.2.0, the problem is coming from the `exists` method which has been deprecated before Ruby 2.5 (https://ruby-doc.org/core-2.5.0/File.html#method-c-exists-3F
) and no longer exist (the irony ahah) in Ruby 3.2.0 

Do you think these changes are relevant to you ? :)

Thank you for taking the time to review my PR.

Best regards,

Thornolf