### PR TITLE
Update pdftoimage.rb to fix "Error determining page count"

### DIFF
--- a/lib/pdftoimage.rb
+++ b/lib/pdftoimage.rb
@@ -74,7 +74,7 @@ module PDFToImage
         private
 
         def page_size(filename, page)
-            cmd = "pdfinfo -f #{page} -l #{page} #{Shellwords.escape(filename)} | grep Page"
+            cmd = "pdfinfo -f #{page} -l #{page} #{Shellwords.escape(filename)} | grep -a Page"
             output = exec(cmd)
 
             matches = /^Page.*?size:.*?(\d+).*?(\d+)/.match(output)
@@ -92,7 +92,7 @@ module PDFToImage
         end
 
         def page_count(filename)
-            cmd = "pdfinfo #{Shellwords.escape(filename)} | grep Pages"
+            cmd = "pdfinfo #{Shellwords.escape(filename)} | grep -a Pages"
             output = exec(cmd)
             matches = /^Pages:.*?(\d+)$/.match(output)
             if matches.nil?


### PR DESCRIPTION
Hello.
This update fix error with some PDF files. In old version Grep fails with " Binary file (standard input) matches"

https://github.com/robflynn/pdftoimage/issues/6