### PR TITLE
chore: Replace direct ImageMagick CLI calls with MiniMagick

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,58 +3,96 @@ PATH
   specs:
     pdftoimage (0.2.1)
       iconv (~> 1.0)
+      mini_magick (>= 4.0)
       shellwords (~> 0.2.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    ast (2.4.0)
+    addressable (2.8.9)
+      public_suffix (>= 2.0.2, < 8.0)
+    ast (2.4.3)
     autotest (5.0.0)
       minitest-autotest (~> 1.0)
-    diff-lcs (1.3)
-    iconv (1.1.0)
-    mini_magick (4.12.0)
-    minitest (5.18.0)
-    minitest-autotest (1.1.1)
-      minitest-server (~> 1.0)
-      path_expander (~> 1.0)
-    minitest-server (1.0.7)
-      minitest (~> 5.16)
-    parallel (1.12.1)
-    parser (2.5.1.0)
-      ast (~> 2.4.0)
-    path_expander (1.1.1)
-    powerpack (0.1.1)
-    rainbow (3.0.0)
+    bigdecimal (4.0.1)
+    date (3.5.1)
+    diff-lcs (1.6.2)
+    drb (2.2.3)
+    erb (6.0.2)
+    iconv (1.1.1)
+    json (2.19.2)
+    json-schema (6.2.0)
+      addressable (~> 2.8)
+      bigdecimal (>= 3.1, < 5)
+    language_server-protocol (3.17.0.5)
+    lint_roller (1.1.0)
+    logger (1.7.0)
+    mcp (0.8.0)
+      json-schema (>= 4.1)
+    mini_magick (5.3.1)
+      logger
+    minitest (6.0.2)
+      drb (~> 2.0)
+      prism (~> 1.5)
+    minitest-autotest (1.2.1)
+      minitest (~> 6.0)
+    parallel (1.27.0)
+    parser (3.3.10.2)
+      ast (~> 2.4.1)
+      racc
+    prism (1.9.0)
+    psych (5.3.1)
+      date
+      stringio
+    public_suffix (7.0.5)
+    racc (1.8.1)
+    rainbow (3.1.1)
     rake (12.3.3)
-    rdoc (6.0.3)
-    rspec (3.7.0)
-      rspec-core (~> 3.7.0)
-      rspec-expectations (~> 3.7.0)
-      rspec-mocks (~> 3.7.0)
-    rspec-core (3.7.1)
-      rspec-support (~> 3.7.0)
-    rspec-expectations (3.7.0)
+    rdoc (7.2.0)
+      erb
+      psych (>= 4.0.0)
+      tsort
+    regexp_parser (2.11.3)
+    rspec (3.13.2)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.6)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-mocks (3.7.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.8)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-support (3.7.1)
-    rubocop (0.55.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.7)
+    rubocop (1.85.1)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      mcp (~> 0.6)
       parallel (~> 1.10)
-      parser (>= 2.5)
-      powerpack (~> 0.1)
+      parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.49.0, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (~> 1.0, >= 1.0.1)
-    ruby-progressbar (1.9.0)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.49.1)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
+    ruby-progressbar (1.13.0)
     shellwords (0.2.2)
     spork (0.9.2)
-    unicode-display_width (1.3.2)
-    yard (0.9.12)
+    stringio (3.2.0)
+    tsort (0.2.0)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.2.0)
+    yard (0.9.38)
 
 PLATFORMS
+  arm64-darwin-24
   ruby
 
 DEPENDENCIES
@@ -68,5 +106,51 @@ DEPENDENCIES
   spork
   yard
 
+CHECKSUMS
+  addressable (2.8.9) sha256=cc154fcbe689711808a43601dee7b980238ce54368d23e127421753e46895485
+  ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
+  autotest (5.0.0) sha256=213bc63d59455ce81e6fffd9afc09b18acae578a5871e66f1f0e089e72d239ec
+  bigdecimal (4.0.1) sha256=8b07d3d065a9f921c80ceaea7c9d4ae596697295b584c296fe599dd0ad01c4a7
+  date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
+  diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
+  drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
+  erb (6.0.2) sha256=9fe6264d44f79422c87490a1558479bd0e7dad4dd0e317656e67ea3077b5242b
+  iconv (1.1.1) sha256=6ac2b9e060d1ed3a18f4cd1ef262f90d3700d3151ead875ffc664180f968350d
+  json (2.19.2) sha256=e7e1bd318b2c37c4ceee2444841c86539bc462e81f40d134cf97826cb14e83cf
+  json-schema (6.2.0) sha256=e8bff46ed845a22c1ab2bd0d7eccf831c01fe23bb3920caa4c74db4306813666
+  language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
+  lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
+  logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
+  mcp (0.8.0) sha256=ae8bd146bb8e168852866fd26f805f52744f6326afb3211e073f78a95e0c34fb
+  mini_magick (5.3.1) sha256=29395dfd76badcabb6403ee5aff6f681e867074f8f28ce08d78661e9e4a351c4
+  minitest (6.0.2) sha256=db6e57956f6ecc6134683b4c87467d6dd792323c7f0eea7b93f66bd284adbc3d
+  minitest-autotest (1.2.1) sha256=971ca79a6910ab4c6348837415981662e98bebb03656df203464c2d081b28c8d
+  parallel (1.27.0) sha256=4ac151e1806b755fb4e2dc2332cbf0e54f2e24ba821ff2d3dcf86bf6dc4ae130
+  parser (3.3.10.2) sha256=6f60c84aa4bdcedb6d1a2434b738fe8a8136807b6adc8f7f53b97da9bc4e9357
+  pdftoimage (0.2.1)
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
+  psych (5.3.1) sha256=eb7a57cef10c9d70173ff74e739d843ac3b2c019a003de48447b2963d81b1974
+  public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
+  rake (12.3.3) sha256=f7694adb4fe638da35452300cee6c545e9c377a0e3190018ac04d590b3c26ab3
+  rdoc (7.2.0) sha256=8650f76cd4009c3b54955eb5d7e3a075c60a57276766ebf36f9085e8c9f23192
+  regexp_parser (2.11.3) sha256=ca13f381a173b7a93450e53459075c9b76a10433caadcb2f1180f2c741fc55a4
+  rspec (3.13.2) sha256=206284a08ad798e61f86d7ca3e376718d52c0bc944626b2349266f239f820587
+  rspec-core (3.13.6) sha256=a8823c6411667b60a8bca135364351dda34cd55e44ff94c4be4633b37d828b2d
+  rspec-expectations (3.13.5) sha256=33a4d3a1d95060aea4c94e9f237030a8f9eae5615e9bd85718fe3a09e4b58836
+  rspec-mocks (3.13.8) sha256=086ad3d3d17533f4237643de0b5c42f04b66348c28bf6b9c2d3f4a3b01af1d47
+  rspec-support (3.13.7) sha256=0640e5570872aafefd79867901deeeeb40b0c9875a36b983d85f54fb7381c47c
+  rubocop (1.85.1) sha256=3dbcf9e961baa4c376eeeb2a03913dca5e3987033b04d38fa538aa1e7406cc77
+  rubocop-ast (1.49.1) sha256=4412f3ee70f6fe4546cc489548e0f6fcf76cafcfa80fa03af67098ffed755035
+  ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
+  shellwords (0.2.2) sha256=b8695a791de2f71472de5abdc3f4332f6535a4177f55d8f99e7e44266cd32f94
+  spork (0.9.2) sha256=46d227b74a90c5a34d1275c836a8405b40755101a17ae07702d026109b77cb82
+  stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
+  tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f
+  unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42
+  unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
+  yard (0.9.38) sha256=721fb82afb10532aa49860655f6cc2eaa7130889df291b052e1e6b268283010f
+
 BUNDLED WITH
-   1.17.3
+  4.0.8

--- a/lib/pdftoimage.rb
+++ b/lib/pdftoimage.rb
@@ -4,6 +4,7 @@ require 'pdftoimage/image'
 require 'tmpdir'
 require 'iconv'
 require 'shellwords'
+require 'mini_magick'
 
 module PDFToImage
     class PDFError < RuntimeError; end
@@ -18,13 +19,6 @@ module PDFToImage
         raise(PDFToImage::PDFError, "poppler_utils not installed") unless tmp.index('Poppler')
     rescue Errno::ENOENT
         raise PDFToImage::PDFError, "poppler_utils not installed"
-    end
-
-    begin
-        tmp = `identify -version 2>&1`
-        raise(PDFToImage::PDFError, "ImageMagick not installed") unless tmp.index('ImageMagick')
-    rescue Errno::ENOENT
-        raise PDFToImage::PDFError, "ImageMagick not installed"
     end
 
     class << self

--- a/lib/pdftoimage/image.rb
+++ b/lib/pdftoimage/image.rb
@@ -26,7 +26,7 @@ module PDFToImage
 
         CUSTOM_IMAGE_METHODS.each do |method|
             define_method(method.to_sym) do |*args|
-                @args << "-#{method} #{args.join(' ')}"
+                @args << [method, args]
 
                 self
             end
@@ -69,15 +69,11 @@ module PDFToImage
         def save(outname)
             generate_temp_file
 
-            cmd = "convert "
-
-            if not @args.empty?
-                cmd += "#{@args.join(' ')} "
+            image = MiniMagick::Image.open(@filename)
+            @args.each do |method, args|
+                image.send(method, *args)
             end
-
-            cmd += "#{Shellwords.escape(@filename)} #{Shellwords.escape(outname)}"
-
-            PDFToImage.exec(cmd)
+            image.write(outname)
 
             return true
         end

--- a/pdftoimage.gemspec
+++ b/pdftoimage.gemspec
@@ -15,4 +15,5 @@ Gem::Specification.new do |s|
 
     s.add_dependency 'iconv', '~> 1.0'
     s.add_dependency 'shellwords', '~> 0.2.2'
+    s.add_dependency 'mini_magick', '>= 4.0'
 end


### PR DESCRIPTION
This PR replaces the old deprecated `convert` command with minimagick proper.
