### PR TITLE
Add support for opening PDFs from remote URLs  [#2]

### DIFF
--- a/lib/pdftoimage.rb
+++ b/lib/pdftoimage.rb
@@ -5,6 +5,8 @@ require 'tmpdir'
 require 'iconv'
 require 'shellwords'
 require 'mini_magick'
+require 'open-uri'
+require 'uri'
 
 module PDFToImage
     class PDFError < RuntimeError; end
@@ -28,6 +30,8 @@ module PDFToImage
         #
         # @return [Array] An array of images
         def open(filename, &block)
+            filename = download_file(filename) if url?(filename)
+
             if not File.exist?(filename)
                 raise PDFError, "File '#{filename}' not found."
             end
@@ -94,6 +98,25 @@ module PDFToImage
             end
 
             return matches[1].to_i
+        end
+
+        def url?(filename)
+            uri = URI.parse(filename)
+            uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
+        rescue URI::InvalidURIError
+            false
+        end
+
+        def download_file(url)
+            tempfile = File.join(@@pdf_temp_dir, "#{random_name}.pdf")
+            remote = URI.open(url)
+            File.open(tempfile, 'wb') do |file|
+                file.write(remote.read)
+            end
+            remote.close
+            tempfile
+        rescue OpenURI::HTTPError, SocketError, Errno::ECONNREFUSED => e
+            raise PDFError, "Failed to download '#{url}': #{e.message}"
         end
 
         # Generate a random file name in the system's tmp folder

--- a/spec/pdftoimage_spec.rb
+++ b/spec/pdftoimage_spec.rb
@@ -59,7 +59,7 @@ describe PDFToImage do
             PDFToImage.open("spec/include blanks.pdf") do |page|
                 counter = counter + 1
             end
-            counter.should equal 3
+            expect(counter).to eq(3)
         end
     end
 
@@ -124,6 +124,38 @@ describe PDFToImage do
             expect(resolution).to eq(target_dpcm)
 
             File.unlink("spec/300dpi-test.jpg")
+        end
+    end
+
+    describe "remote URLs" do
+        after(:each) do
+            @local_pdf&.close
+        end
+
+        it "should download and open a PDF from a URL" do
+            @local_pdf = File.open('spec/3pages.pdf', 'rb')
+            allow(URI).to receive(:open).with("http://example.com/test.pdf").and_return(@local_pdf)
+
+            pages = PDFToImage.open("http://example.com/test.pdf")
+            expect(pages.size).to eq(3)
+        end
+
+        it "should save pages from a remote PDF" do
+            @local_pdf = File.open('spec/3pages.pdf', 'rb')
+            allow(URI).to receive(:open).with("http://example.com/test.pdf").and_return(@local_pdf)
+
+            pages = PDFToImage.open("http://example.com/test.pdf")
+            pages[0].save('spec/remote_tmp.jpg')
+            expect(File.exist?('spec/remote_tmp.jpg')).to eq(true)
+            File.unlink('spec/remote_tmp.jpg')
+        end
+
+        it "should raise PDFError when download fails" do
+            allow(URI).to receive(:open).and_raise(OpenURI::HTTPError.new("404 Not Found", StringIO.new))
+
+            expect {
+                PDFToImage.open("http://example.com/nonexistent.pdf")
+            }.to raise_error(PDFToImage::PDFError, /Failed to download/)
         end
     end
 end


### PR DESCRIPTION
PDFToImage.open now accepts http/https URLs in addition to local file paths. URLs are detected automatically and downloaded to a temp file before processing.
