### PR TITLE
Remove iconv dependency.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     pdftoimage (0.2.1)
-      iconv (~> 1.0)
       mini_magick (>= 4.0)
       shellwords (~> 0.2.2)
 
@@ -19,7 +18,6 @@ GEM
     diff-lcs (1.6.2)
     drb (2.2.3)
     erb (6.0.2)
-    iconv (1.1.1)
     json (2.19.2)
     json-schema (6.2.0)
       addressable (~> 2.8)
@@ -115,7 +113,6 @@ CHECKSUMS
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   erb (6.0.2) sha256=9fe6264d44f79422c87490a1558479bd0e7dad4dd0e317656e67ea3077b5242b
-  iconv (1.1.1) sha256=6ac2b9e060d1ed3a18f4cd1ef262f90d3700d3151ead875ffc664180f968350d
   json (2.19.2) sha256=e7e1bd318b2c37c4ceee2444841c86539bc462e81f40d134cf97826cb14e83cf
   json-schema (6.2.0) sha256=e8bff46ed845a22c1ab2bd0d7eccf831c01fe23bb3920caa4c74db4306813666
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc

--- a/lib/pdftoimage.rb
+++ b/lib/pdftoimage.rb
@@ -2,7 +2,6 @@ require 'pdftoimage/version'
 require 'pdftoimage/image'
 
 require 'tmpdir'
-require 'iconv'
 require 'shellwords'
 require 'mini_magick'
 require 'open-uri'

--- a/pdftoimage.gemspec
+++ b/pdftoimage.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |s|
         'source_code_uri'   => 'https://github.com/robflynn/pdftoimage/'
     }
 
-    s.add_dependency 'iconv', '~> 1.0'
     s.add_dependency 'shellwords', '~> 0.2.2'
     s.add_dependency 'mini_magick', '>= 4.0'
 end


### PR DESCRIPTION
I think this was an old dependency to solve a utf16/utf8 contlict. It seems to have been lingering around and is was no-longer used?

This PR removes the dependency.
