### PR TITLE
feat: Inline PDF

### DIFF
--- a/lib/pdftoimage.rb
+++ b/lib/pdftoimage.rb
@@ -6,6 +6,7 @@ require 'shellwords'
 require 'mini_magick'
 require 'open-uri'
 require 'uri'
+require 'stringio'
 
 module PDFToImage
     class PDFError < RuntimeError; end
@@ -25,11 +26,17 @@ module PDFToImage
     class << self
         # Opens a PDF document and prepares it for splitting into images.
         #
-        # @param filename [String] The filename of the PDF to open
+        # @param source [String, IO] A filename, URL, or IO object containing PDF data
         #
         # @return [Array] An array of images
-        def open(filename, &block)
-            filename = download_file(filename) if url?(filename)
+        def open(source, &block)
+            filename = if source.respond_to?(:read)
+                write_to_tempfile(source.read)
+            elsif url?(source)
+                download_file(source)
+            else
+                source
+            end
 
             if not File.exist?(filename)
                 raise PDFError, "File '#{filename}' not found."
@@ -49,6 +56,16 @@ module PDFToImage
             images.each(&block) if block_given?
 
             return images
+        end
+
+        # Opens a PDF from raw binary data.
+        #
+        # @param data [String] Binary string of PDF content
+        #
+        # @return [Array] An array of images
+        def from_blob(data, &block)
+            filename = write_to_tempfile(data)
+            open(filename, &block)
         end
 
         # Executes the specified command, returning the output.
@@ -97,6 +114,12 @@ module PDFToImage
             end
 
             return matches[1].to_i
+        end
+
+        def write_to_tempfile(data)
+            tempfile = File.join(@@pdf_temp_dir, "#{random_name}.pdf")
+            File.open(tempfile, 'wb') { |f| f.write(data) }
+            tempfile
         end
 
         def url?(filename)

--- a/lib/pdftoimage.rb
+++ b/lib/pdftoimage.rb
@@ -30,13 +30,7 @@ module PDFToImage
         #
         # @return [Array] An array of images
         def open(source, &block)
-            filename = if source.respond_to?(:read)
-                write_to_tempfile(source.read)
-            elsif url?(source)
-                download_file(source)
-            else
-                source
-            end
+            filename = resolve_source(source)
 
             if not File.exist?(filename)
                 raise PDFError, "File '#{filename}' not found."
@@ -114,6 +108,16 @@ module PDFToImage
             end
 
             return matches[1].to_i
+        end
+
+        def resolve_source(source)
+            if source.respond_to?(:read)
+                write_to_tempfile(source.read)
+            elsif url?(source)
+                download_file(source)
+            else
+                source
+            end
         end
 
         def write_to_tempfile(data)

--- a/lib/pdftoimage/image.rb
+++ b/lib/pdftoimage/image.rb
@@ -1,3 +1,5 @@
+require 'tempfile'
+
 module PDFToImage
     # A class which is instantiated by PDFToImage when a PDF document
     # is opened.
@@ -67,13 +69,11 @@ module PDFToImage
         # @param outname [String] The output filename of the image
         #
         def save(outname)
-            generate_temp_file
-
-            image = MiniMagick::Image.open(@filename)
-            @args.each do |method, args|
-                image.send(method, *args)
+            if outname.respond_to?(:write)
+                save_to_io(outname)
+            else
+                save_to_file(outname)
             end
-            image.write(outname)
 
             return true
         end
@@ -89,6 +89,29 @@ module PDFToImage
         end
 
       private
+
+        def save_to_file(outname)
+            generate_temp_file
+
+            image = MiniMagick::Image.open(@filename)
+            @args.each do |method, args|
+                image.send(method, *args)
+            end
+            image.write(outname)
+        end
+
+        def save_to_io(io)
+            tempfile = Tempfile.new(['pdftoimage', '.png'])
+            tempfile.binmode
+            begin
+                save_to_file(tempfile.path)
+                tempfile.rewind
+                IO.copy_stream(tempfile, io)
+            ensure
+                tempfile.close
+                tempfile.unlink
+            end
+        end
 
         def generate_temp_file
             if @opened == false

--- a/spec/pdftoimage_spec.rb
+++ b/spec/pdftoimage_spec.rb
@@ -158,4 +158,68 @@ describe PDFToImage do
             }.to raise_error(PDFToImage::PDFError, /Failed to download/)
         end
     end
+
+    describe "IO input" do
+        it "should open a PDF from an IO object" do
+            File.open('spec/3pages.pdf', 'rb') do |io|
+                pages = PDFToImage.open(io)
+                expect(pages.size).to eq(3)
+            end
+        end
+
+        it "should open a PDF from a StringIO" do
+            data = File.read('spec/3pages.pdf', mode: 'rb')
+            io = StringIO.new(data)
+            pages = PDFToImage.open(io)
+            expect(pages.size).to eq(3)
+        end
+
+        it "should save pages from an IO-opened PDF" do
+            File.open('spec/3pages.pdf', 'rb') do |io|
+                pages = PDFToImage.open(io)
+                pages[0].save('spec/io_tmp.jpg')
+                expect(File.exist?('spec/io_tmp.jpg')).to eq(true)
+                File.unlink('spec/io_tmp.jpg')
+            end
+        end
+    end
+
+    describe "from_blob" do
+        it "should open a PDF from binary data" do
+            data = File.read('spec/3pages.pdf', mode: 'rb')
+            pages = PDFToImage.from_blob(data)
+            expect(pages.size).to eq(3)
+        end
+
+        it "should save pages from a blob-opened PDF" do
+            data = File.read('spec/3pages.pdf', mode: 'rb')
+            pages = PDFToImage.from_blob(data)
+            pages[0].save('spec/blob_tmp.jpg')
+            expect(File.exist?('spec/blob_tmp.jpg')).to eq(true)
+            File.unlink('spec/blob_tmp.jpg')
+        end
+
+        it "should work with blocks" do
+            data = File.read('spec/3pages.pdf', mode: 'rb')
+            counter = 0
+            PDFToImage.from_blob(data) { |page| counter += 1 }
+            expect(counter).to eq(3)
+        end
+    end
+
+    describe "saving to IO" do
+        it "should produce identical output to saving to a file" do
+            pages = PDFToImage.open('spec/3pages.pdf')
+
+            pages[0].save('spec/io_compare_tmp.jpg')
+            file_content = File.read('spec/io_compare_tmp.jpg', mode: 'rb')
+            File.unlink('spec/io_compare_tmp.jpg')
+
+            io = StringIO.new(''.b)
+            pages[0].save(io)
+            io.rewind
+
+            expect(io.read).to eq(file_content)
+        end
+    end
 end


### PR DESCRIPTION
Adds support for opening PDFs via IO objects and raw binary data.  It also allows for saving to IO objects. This allows for file-free workflows when needed.

```
  # From a File IO
  File.open("report.pdf", "rb") do |io|
    pages = PDFToImage.open(io)
    pages[0].save("page1.png")
  end
```

```
  # From any IO-like object (e.g. a Tempfile, Socket, etc.)
  pages = PDFToImage.open(some_stream)

  PDFToImage.from_blob for raw binary data
```

```
  # From binary string data
  pdf_data = download_pdf_from_s3(key)
  pages = PDFToImage.from_blob(pdf_data)
  pages[0].resize("50%").save("thumbnail.png")
```

```
  # Saving to IO
  pages = PDFToImage.open("report.pdf")
  io = StringIO.new("".b)
  pages[0].save(io)
  io.rewind
  upload_to_s3(io)

```