### PR TITLE
feat: Add 'crop' method for cropping a portion of the PDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ pages[0].save(io)
 io.rewind
 ```
 
+### Cropping a region
+
+```ruby
+PDFToImage.open('report.pdf') do |page|
+  page.crop(0, 300, 100, 300).save("out/cropped-#{page.page}.jpg")
+end
+```
+
 ### Setting resolution
 
 ```ruby

--- a/lib/pdftoimage/image.rb
+++ b/lib/pdftoimage/image.rb
@@ -78,6 +78,12 @@ module PDFToImage
             return true
         end
 
+        def crop(x, y, w, h)
+            @pdf_args.push("-x #{x}", "-y #{y}", "-W #{w}", "-H #{h}")
+
+            self
+        end
+
         def <=>(img)
             if @page == img.page
                 return 0

--- a/spec/pdftoimage_spec.rb
+++ b/spec/pdftoimage_spec.rb
@@ -207,6 +207,27 @@ describe PDFToImage do
         end
     end
 
+    describe "crop" do
+        it "should save a cropped image" do
+            pages = PDFToImage.open('spec/3pages.pdf')
+            pages[0].crop(0, 0, 100, 100).save('spec/crop_tmp.jpg')
+            expect(File.exist?('spec/crop_tmp.jpg')).to eq(true)
+
+            image = MiniMagick::Image.open('spec/crop_tmp.jpg')
+            expect(image.width).to eq(100)
+            expect(image.height).to eq(100)
+
+            File.unlink('spec/crop_tmp.jpg')
+        end
+
+        it "should be chainable with other methods" do
+            pages = PDFToImage.open('spec/3pages.pdf')
+            pages[0].crop(0, 0, 200, 200).quality('80%').save('spec/crop_chain_tmp.jpg')
+            expect(File.exist?('spec/crop_chain_tmp.jpg')).to eq(true)
+            File.unlink('spec/crop_chain_tmp.jpg')
+        end
+    end
+
     describe "saving to IO" do
         it "should produce identical output to saving to a file" do
             pages = PDFToImage.open('spec/3pages.pdf')


### PR DESCRIPTION
This PR adds a `crop(x, y, w, h)` method to `PDFToImage::Image` for extracting rectangular regions from PDF pages
